### PR TITLE
Add Custom Function Runtime

### DIFF
--- a/src/constants/function_runtime.ts
+++ b/src/constants/function_runtime.ts
@@ -7,6 +7,7 @@ export enum FunctionRuntimeConstant {
     Powershell,
     Java,
     Python,
+    Custom
 }
 
 export class FunctionRuntimeUtil {


### PR DESCRIPTION
To enable Azure Functions Custom Handlers deployments via this github action

When running the current deploy-function github action it cannot deploy a custom handler azure function, you get the following error 
```bash
Run Azure/functions-action@v1
##[Initialize]
##[ValidateParameter]
##[ValidateAzureResource]
Using RBAC for authentication, GitHub Action will perform resource validation.
Sucessfully acquired site configs from function app!
Detected function app sku: Consumption
Sucessfully acquired app settings from function app (RBAC)!
Error: Execution Exception (state: ValidateAzureResource) (step: Invocation)
Error:   Failed to convert custom to FunctionRuntimeConstant
Error: Deployment Failed!
```

Custom handlers now has a Custom Runtime (in preview) as mentioned in the docs https://docs.microsoft.com/en-us/azure/azure-functions/functions-custom-handlers#deploying

To support custom handlers via this github action we need to add Custom as a function runtime constant 