### PR TITLE
Support Java function app pom.xml parsing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,11 @@ inputs:
   publish-profile:
     description: 'Publish profile (*.publishsettings) file contents with web deploy secrets'
     required: false
+  respect-pom-xml:
+    description: "Automatically look up Java function app artifact from pom.xml (default: 'false').
+                  When this is set to 'true', publish-profile should point to the folder of host.json."
+    required: false
+    default: 'false'
 outputs:
   app-url:
     description: 'URL to work with your function app'

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "@types/xml2js": "^0.4.5",
     "@actions/core": "^1.2.6",
     "@azure/storage-blob": "^10.4.0",
-    "azure-actions-appservice-rest": "^1.0.9",
+    "azure-actions-appservice-rest": "^1.3.0",
     "azure-actions-utility": "^1.0.3",
-    "azure-actions-webclient": "^1.0.11",
+    "azure-actions-webclient": "^1.1.0",
     "xml2js": "^0.4.23"
   }
 }

--- a/src/constants/configuration.ts
+++ b/src/constants/configuration.ts
@@ -3,6 +3,8 @@ export class ConfigurationConstant {
     public static readonly ParamInPackagePath: string = 'package';
     public static readonly ParamInSlot: string = 'slot-name';
     public static readonly ParamInPublishProfile: string = 'publish-profile';
+    public static readonly ParamInRespectPomXml: string = 'respect-pom-xml';
+
     public static readonly ParamOutResultName: string = 'app-url';
 
     public static readonly ActionName: string = 'DeployFunctionAppToAzure';

--- a/src/handlers/parameterValidator.ts
+++ b/src/handlers/parameterValidator.ts
@@ -13,12 +13,14 @@ import { ValidationError } from '../exceptions';
 import { parseString } from 'xml2js';
 import { Builder } from '../managers/builder';
 import { Logger } from '../utils/logger';
+import { Parser } from '../utils/parser';
 
 export class ParameterValidator implements IOrchestratable {
     private _appName: string;
     private _packagePath: string;
     private _slot: string;
     private _publishProfile: string;
+    private _respectPomXml: string;
     private _scmCredentials: IScmCredentials
 
     constructor() {
@@ -27,10 +29,14 @@ export class ParameterValidator implements IOrchestratable {
     }
 
     public async invoke(state: StateConstant): Promise<StateConstant> {
+        // Parse action input from action.xml
         this._appName = core.getInput(ConfigurationConstant.ParamInAppName);
         this._packagePath = core.getInput(ConfigurationConstant.ParamInPackagePath);
         this._slot = core.getInput(ConfigurationConstant.ParamInSlot);
         this._publishProfile = core.getInput(ConfigurationConstant.ParamInPublishProfile);
+        this._respectPomXml = core.getInput(ConfigurationConstant.ParamInRespectPomXml);
+
+        // Validate field
         if (this._slot !== undefined && this._slot.trim() === "") {
             this._slot = undefined;
         }
@@ -45,6 +51,7 @@ export class ParameterValidator implements IOrchestratable {
         params.packagePath = this._packagePath;
         params.slot = this._slot;
         params.publishProfile = this._publishProfile;
+        params.respectPomXml = Parser.IsTrueLike(this._respectPomXml);
         return params;
     }
 

--- a/src/interfaces/IActionParameters.ts
+++ b/src/interfaces/IActionParameters.ts
@@ -3,4 +3,5 @@ export interface IActionParameters {
     packagePath: string;
     slot: string;
     publishProfile: string;
+    respectPomXml: boolean;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,17 @@
+/*
+ * This code snippet needs to be executed at the very beginning of the action.
+ * Since the underlying azure-actions-appservice-rest will load the AZURE_HTTP_USER_AGENT
+ * environment variable in the initialization.
+ * Thus, the AZURE_HTTP_USER_AGENT needs to be set before any rest request.
+ */
 import * as core from '@actions/core';
+import * as crypto from "crypto";
+import { ConfigurationConstant } from './constants/configuration';
+const prefix = !!process.env.AZURE_HTTP_USER_AGENT ? `${process.env.AZURE_HTTP_USER_AGENT}` : "";
+const usrAgentRepo = crypto.createHash('sha256').update(`${process.env.GITHUB_REPOSITORY}`).digest('hex');
+const actionName = ConfigurationConstant.ActionName;
+const userAgentString = (!!prefix ? `${prefix}+` : '') + `GITHUBACTIONS_${actionName}_${usrAgentRepo}`;
+core.exportVariable('AZURE_HTTP_USER_AGENT', userAgentString);
 
 import { Orchestrator } from './managers/orchestrator';
 import { StateConstant } from './constants/state';
@@ -9,7 +22,7 @@ import { ContentPreparer } from './handlers/contentPreparer';
 import { ContentPublisher } from './handlers/contentPublisher';
 import { PublishValidator } from './handlers/publishValidator';
 import { Logger } from './utils';
-import { UnexpectedExitException, ExecutionException, BaseException } from './exceptions';
+import { UnexpectedExitException, BaseException } from './exceptions';
 
 
 async function main(): Promise<void> {

--- a/src/managers/builder.ts
+++ b/src/managers/builder.ts
@@ -17,7 +17,8 @@ export class Builder {
             appName: undefined,
             packagePath: undefined,
             slot: undefined,
-            publishProfile: undefined
+            publishProfile: undefined,
+            respectPomXml: false
         }
     }
 

--- a/tests/handlers/contentPreparer.spec.ts
+++ b/tests/handlers/contentPreparer.spec.ts
@@ -8,8 +8,9 @@ import { RuntimeStackConstant } from '../../src/constants/runtime_stack';
 import { FunctionSkuConstant } from '../../src/constants/function_sku';
 import { AuthenticationType } from '../../src/constants/authentication_type';
 import { PublishMethodConstant } from '../../src/constants/publish_method';
+import { Builder } from '../../src/managers/builder';
 
-describe('ContentPreparer', function () {
+describe('Check ContentPreparer', function () {
   let _rootPath: string;
   const _envBackup = process.env;
 
@@ -62,9 +63,13 @@ describe('ContentPreparer', function () {
   it('should generate zip file path to publish', async function () {
     const preparer = new ContentPreparer();
     const zipPath = `${_rootPath}/tests/sample/NetCoreApp.zip`;
+
+    const params = Builder.GetDefaultActionParameters();
+    params.packagePath = zipPath;
+
     // @ts-ignore
     const publishPath = await preparer.generatePublishContent(
-      StateConstant.PreparePublishContent, zipPath, PackageType.zip
+      StateConstant.PreparePublishContent, params, PackageType.zip
     );
     expect(publishPath).to.equal(zipPath);
   });
@@ -74,9 +79,31 @@ describe('ContentPreparer', function () {
     const folderPath = `${_rootPath}/tests/sample/NetCoreAppFolder`;
     process.env.RUNNER_TEMP = `${_rootPath}/tests/temp`;
 
+    const params = Builder.GetDefaultActionParameters();
+    params.packagePath = folderPath;
+
     // @ts-ignore
     const publishPath = await preparer.generatePublishContent(
-      StateConstant.PreparePublishContent, folderPath, PackageType.folder
+      StateConstant.PreparePublishContent, params, PackageType.folder
+    );
+
+    // Clean up
+    unlinkSync(publishPath);
+    expect(publishPath).to.contains('.zip');
+  });
+
+  it('should archive java function app follow pom.xml', async function () {
+    const preparer = new ContentPreparer();
+    const folderPath = `${_rootPath}/tests/sample/JavaAppFolder`;
+    process.env.RUNNER_TEMP = `${_rootPath}/tests/temp`;
+
+    const params = Builder.GetDefaultActionParameters();
+    params.packagePath = folderPath;
+    params.respectPomXml = true;
+
+    // @ts-ignore
+    const publishPath = await preparer.generatePublishContent(
+      StateConstant.PreparePublishContent, params, PackageType.folder
     );
 
     // Clean up
@@ -89,10 +116,13 @@ describe('ContentPreparer', function () {
     const folderPath = `${_rootPath}/tests/sample/NetCoreAppFolder`;
     process.env.RUNNER_TEMP = `${_rootPath}/folder/does/not/exist`;
 
+    const params = Builder.GetDefaultActionParameters();
+    params.packagePath = folderPath;
+
     try {
       // @ts-ignore
       await preparer.generatePublishContent(
-        StateConstant.PreparePublishContent, folderPath, PackageType.folder
+        StateConstant.PreparePublishContent, params, PackageType.folder
       );
     } catch (e) {
       expect(e.message).to.contains('Failed to archive');
@@ -103,10 +133,13 @@ describe('ContentPreparer', function () {
     const preparer = new ContentPreparer();
     const folderPath = `${_rootPath}/tests/sample/NetCoreAppFolder`;
 
+    const params = Builder.GetDefaultActionParameters();
+    params.packagePath = folderPath;
+
     try {
       // @ts-ignore
       await preparer.generatePublishContent(
-        StateConstant.PreparePublishContent, folderPath, PackageType.jar
+        StateConstant.PreparePublishContent, params, PackageType.jar
       );
     } catch (e) {
       expect(e.message).to.contains('only accepts zip or folder');
@@ -173,5 +206,32 @@ describe('ContentPreparer', function () {
         });
       });
     });
+  });
+
+  it('should parse java pom.xml to get the function app name', async function () {
+    const preparer = new ContentPreparer();
+    const packagePath = resolve(_rootPath, 'tests', 'samples', 'JavaAppFolder');
+    const expectedSourceFolder = resolve(packagePath, 'target', 'azure-functions', 'hazeng-fa-java');
+    // @ts-ignore
+    const sourceFolder = await preparer.getPomXmlSourceLocation(packagePath);
+    expect(sourceFolder).to.equal(expectedSourceFolder);
+  });
+
+  it('should ignore java local app name if pom.xml is not found', async function () {
+    const preparer = new ContentPreparer();
+    const packagePath = resolve(_rootPath, 'tests');
+    const expectedSourceFolder = packagePath;
+    // @ts-ignore
+    const sourceFolder = await preparer.getPomXmlSourceLocation(packagePath);
+    expect(sourceFolder).to.equal(expectedSourceFolder);
+  });
+
+  it('should ignore java local app name if pom.xml cannot be parsed', async function () {
+    const preparer = new ContentPreparer();
+    const packagePath = resolve(_rootPath, 'tests', 'samples', 'BrokenJavaAppFolder');
+    const expectedSourceFolder = packagePath;
+    // @ts-ignore
+    const sourceFolder = await preparer.getPomXmlSourceLocation(packagePath);
+    expect(sourceFolder).to.equal(expectedSourceFolder);
   });
 });

--- a/tests/handlers/initializer.spec.ts
+++ b/tests/handlers/initializer.spec.ts
@@ -1,0 +1,69 @@
+import { expect, assert } from 'chai';
+import { Builder } from '../../src/managers/builder';
+import { StateConstant } from '../../src/constants/state';
+import { Initializer } from '../../src/handlers/initializer';
+
+describe('Check Initializer', function () {
+  const _envBackup = process.env;
+
+  beforeEach(() => {
+    process.env = { ..._envBackup };
+  });
+
+  afterEach(() => {
+    process.env = _envBackup;
+  });
+
+  it('should return an empty string if AZURE_HTTP_USER_AGENT is not set', function () {
+    const initializer = new Initializer();
+    // @ts-ignore
+    const prefix = initializer.getUserAgentPrefix();
+    expect(prefix).to.equal('');
+  });
+
+  it('should return the AZURE_HTTP_USER_AGENT to prefix if set', function () {
+    const initializer = new Initializer();
+    process.env.AZURE_HTTP_USER_AGENT = 'firefox';
+    // @ts-ignore
+    const prefix = initializer.getUserAgentPrefix();
+    expect(prefix).to.equal('firefox');
+  });
+
+  it('should return full agent name if prefix is set', function () {
+    const initializer = new Initializer();
+    process.env.AZURE_HTTP_USER_AGENT = 'chrome';
+    process.env.GITHUB_REPOSITORY = 'repo';
+    // @ts-ignore
+    const agentName = initializer.getUserAgent();
+    expect(agentName).to.equal('chrome+GITHUBACTIONS_DeployFunctionAppToAzure_071ca2227754705837aa3ef9748ed59e9f8a015fd765c42f391a4cbc271c6d5e');
+  });
+
+  it('should return agent name without prefix if AZURE_HTTP_USER_AGENT is not set', function () {
+    const initializer = new Initializer();
+    process.env.GITHUB_REPOSITORY = 'repo';
+    // @ts-ignore
+    const agentName = initializer.getUserAgent();
+    expect(agentName).to.equal('GITHUBACTIONS_DeployFunctionAppToAzure_071ca2227754705837aa3ef9748ed59e9f8a015fd765c42f391a4cbc271c6d5e');
+  });
+
+  it('should run invocation', async function () {
+    const initializer = new Initializer();
+    process.env.AZURE_HTTP_USER_AGENT = 'webkit';
+    process.env.GITHUB_REPOSITORY = 'repo';
+    // @ts-ignore
+    const nextStep = await initializer.invoke();
+    expect(nextStep).to.equal(StateConstant.ValidateParameter);
+  });
+
+  it('should run changeContext', async function () {
+    const initializer = new Initializer();
+    const params = Builder.GetDefaultActionParameters();
+    const context = Builder.GetDefaultActionContext();
+    process.env.AZURE_HTTP_USER_AGENT = 'webkit';
+    process.env.GITHUB_REPOSITORY = 'repo';
+    // @ts-ignore
+    await initializer.changeContext(StateConstant.Initialize, params, context);
+    expect(context.azureHttpUserAgentPrefix).to.equal('webkit');
+    expect(context.azureHttpUserAgent).to.equal('webkit+GITHUBACTIONS_DeployFunctionAppToAzure_071ca2227754705837aa3ef9748ed59e9f8a015fd765c42f391a4cbc271c6d5e');
+  });
+});

--- a/tests/handlers/parameterValidator.spec.ts
+++ b/tests/handlers/parameterValidator.spec.ts
@@ -4,7 +4,7 @@ import { StateConstant } from '../../src/constants/state';
 import { ParameterValidator } from '../../src/handlers/parameterValidator';
 import { IScmCredentials } from '../../src/interfaces/IScmCredentials';
 
-describe('parameterValidator', function () {
+describe('Check ParameterValidator', function () {
   let _rootPath: string;
 
   beforeEach(() => {

--- a/tests/handlers/publishValidator.spec.ts
+++ b/tests/handlers/publishValidator.spec.ts
@@ -1,0 +1,16 @@
+import { expect } from 'chai';
+import { Builder } from '../../src/managers/builder';
+import { StateConstant } from '../../src/constants/state';
+import { PublishValidator } from '../../src/handlers/publishValidator';
+
+describe('Check PublishValidator', function () {
+  it('should invoke properly', async function () {
+    const validator = new PublishValidator();
+    const nextStep = await validator.invoke(
+      StateConstant.ValidatePublishedContent,
+      Builder.GetDefaultActionParameters(),
+      Builder.GetDefaultActionContext()
+    );
+    expect(nextStep).to.equal(StateConstant.Succeeded);
+  });
+});

--- a/tests/managers/builder.spec.ts
+++ b/tests/managers/builder.spec.ts
@@ -16,6 +16,7 @@ describe('builder', function () {
     expect(param.packagePath).to.be.undefined;
     expect(param.publishProfile).to.be.undefined;
     expect(param.slot).to.be.undefined;
+    expect(param.respectPomXml).to.be.false;
   });
 
   it('should build a default action context', function() {

--- a/tests/samples/BrokenJavaAppFolder/host.json
+++ b/tests/samples/BrokenJavaAppFolder/host.json
@@ -1,0 +1,7 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[1.*, 2.0.0)"
+  } 
+}

--- a/tests/samples/BrokenJavaAppFolder/local.settings.json
+++ b/tests/samples/BrokenJavaAppFolder/local.settings.json
@@ -1,0 +1,7 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "",
+    "FUNCTIONS_WORKER_RUNTIME": "java"
+  }
+}

--- a/tests/samples/BrokenJavaAppFolder/pom.xml
+++ b/tests/samples/BrokenJavaAppFolder/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>groupId</groupId>
+    <artifactId>artifactId</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Azure Java Functions</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>1.8</java.version>
+        <azure.functions.maven.plugin.version>1.9.0</azure.functions.maven.plugin.version>
+        <azure.functions.java.library.version>1.4.0</azure.functions.java.library.version>
+        <functionAppName>hazeng-fa-java</functionAppName>
+        <stagingDirectory>${project.build.directory}/azure-functions/${functionAppName}</stagingDirectory>
+BrokenXML

--- a/tests/samples/BrokenJavaAppFolder/src/main/java/groupId/Function.java
+++ b/tests/samples/BrokenJavaAppFolder/src/main/java/groupId/Function.java
@@ -1,0 +1,43 @@
+package groupId;
+
+import com.microsoft.azure.functions.ExecutionContext;
+import com.microsoft.azure.functions.HttpMethod;
+import com.microsoft.azure.functions.HttpRequestMessage;
+import com.microsoft.azure.functions.HttpResponseMessage;
+import com.microsoft.azure.functions.HttpStatus;
+import com.microsoft.azure.functions.annotation.AuthorizationLevel;
+import com.microsoft.azure.functions.annotation.FunctionName;
+import com.microsoft.azure.functions.annotation.HttpTrigger;
+
+import java.util.Optional;
+
+/**
+ * Azure Functions with HTTP Trigger.
+ */
+public class Function {
+    /**
+     * This function listens at endpoint "/api/HttpExample". Two ways to invoke it using "curl" command in bash:
+     * 1. curl -d "HTTP Body" {your host}/api/HttpExample
+     * 2. curl "{your host}/api/HttpExample?name=HTTP%20Query"
+     */
+    @FunctionName("HttpExample")
+    public HttpResponseMessage run(
+            @HttpTrigger(
+                name = "req",
+                methods = {HttpMethod.GET, HttpMethod.POST},
+                authLevel = AuthorizationLevel.ANONYMOUS)
+                HttpRequestMessage<Optional<String>> request,
+            final ExecutionContext context) {
+        context.getLogger().info("Java HTTP trigger processed a request.");
+
+        // Parse query parameter
+        final String query = request.getQueryParameters().get("name");
+        final String name = request.getBody().orElse(query);
+
+        if (name == null) {
+            return request.createResponseBuilder(HttpStatus.BAD_REQUEST).body("Please pass a name on the query string or in the request body").build();
+        } else {
+            return request.createResponseBuilder(HttpStatus.OK).body("Hello, " + name).build();
+        }
+    }
+}

--- a/tests/samples/BrokenJavaAppFolder/src/test/java/groupId/FunctionTest.java
+++ b/tests/samples/BrokenJavaAppFolder/src/test/java/groupId/FunctionTest.java
@@ -1,0 +1,53 @@
+package groupId;
+
+import com.microsoft.azure.functions.*;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.*;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+
+/**
+ * Unit test for Function class.
+ */
+public class FunctionTest {
+    /**
+     * Unit test for HttpTriggerJava method.
+     */
+    @Test
+    public void testHttpTriggerJava() throws Exception {
+        // Setup
+        @SuppressWarnings("unchecked")
+        final HttpRequestMessage<Optional<String>> req = mock(HttpRequestMessage.class);
+
+        final Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("name", "Azure");
+        doReturn(queryParams).when(req).getQueryParameters();
+
+        final Optional<String> queryBody = Optional.empty();
+        doReturn(queryBody).when(req).getBody();
+
+        doAnswer(new Answer<HttpResponseMessage.Builder>() {
+            @Override
+            public HttpResponseMessage.Builder answer(InvocationOnMock invocation) {
+                HttpStatus status = (HttpStatus) invocation.getArguments()[0];
+                return new HttpResponseMessageMock.HttpResponseMessageBuilderMock().status(status);
+            }
+        }).when(req).createResponseBuilder(any(HttpStatus.class));
+
+        final ExecutionContext context = mock(ExecutionContext.class);
+        doReturn(Logger.getGlobal()).when(context).getLogger();
+
+        // Invoke
+        final HttpResponseMessage ret = new Function().run(req, context);
+
+        // Verify
+        assertEquals(ret.getStatus(), HttpStatus.OK);
+    }
+}

--- a/tests/samples/BrokenJavaAppFolder/src/test/java/groupId/HttpResponseMessageMock.java
+++ b/tests/samples/BrokenJavaAppFolder/src/test/java/groupId/HttpResponseMessageMock.java
@@ -1,0 +1,81 @@
+package groupId;
+
+import com.microsoft.azure.functions.*;
+
+import java.util.Map;
+import java.util.HashMap;
+
+/**
+ * The mock for HttpResponseMessage, can be used in unit tests to verify if the
+ * returned response by HTTP trigger function is correct or not.
+ */
+public class HttpResponseMessageMock implements HttpResponseMessage {
+    private int httpStatusCode;
+    private HttpStatusType httpStatus;
+    private Object body;
+    private Map<String, String> headers;
+
+    public HttpResponseMessageMock(HttpStatusType status, Map<String, String> headers, Object body) {
+        this.httpStatus = status;
+        this.httpStatusCode = status.value();
+        this.headers = headers;
+        this.body = body;
+    }
+
+    @Override
+    public HttpStatusType getStatus() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public int getStatusCode() {
+        return httpStatusCode;
+    }
+
+    @Override
+    public String getHeader(String key) {
+        return this.headers.get(key);
+    }
+
+    @Override
+    public Object getBody() {
+        return this.body;
+    }
+
+    public static class HttpResponseMessageBuilderMock implements HttpResponseMessage.Builder {
+        private Object body;
+        private int httpStatusCode;
+        private Map<String, String> headers = new HashMap<>();
+        private HttpStatusType httpStatus;
+
+        public Builder status(HttpStatus status) {
+            this.httpStatusCode = status.value();
+            this.httpStatus = status;
+            return this;
+        }
+
+        @Override
+        public Builder status(HttpStatusType httpStatusType) {
+            this.httpStatusCode = httpStatusType.value();
+            this.httpStatus = httpStatusType;
+            return this;
+        }
+
+        @Override
+        public HttpResponseMessage.Builder header(String key, String value) {
+            this.headers.put(key, value);
+            return this;
+        }
+
+        @Override
+        public HttpResponseMessage.Builder body(Object body) {
+            this.body = body;
+            return this;
+        }
+
+        @Override
+        public HttpResponseMessage build() {
+            return new HttpResponseMessageMock(this.httpStatus, this.headers, this.body);
+        }
+    }
+}

--- a/tests/samples/JavaAppFolder/host.json
+++ b/tests/samples/JavaAppFolder/host.json
@@ -1,0 +1,7 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[1.*, 2.0.0)"
+  } 
+}

--- a/tests/samples/JavaAppFolder/local.settings.json
+++ b/tests/samples/JavaAppFolder/local.settings.json
@@ -1,0 +1,7 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "",
+    "FUNCTIONS_WORKER_RUNTIME": "java"
+  }
+}

--- a/tests/samples/JavaAppFolder/pom.xml
+++ b/tests/samples/JavaAppFolder/pom.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>groupId</groupId>
+    <artifactId>artifactId</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Azure Java Functions</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>1.8</java.version>
+        <azure.functions.maven.plugin.version>1.9.0</azure.functions.maven.plugin.version>
+        <azure.functions.java.library.version>1.4.0</azure.functions.java.library.version>
+        <functionAppName>hazeng-fa-java</functionAppName>
+        <stagingDirectory>${project.build.directory}/azure-functions/${functionAppName}</stagingDirectory>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.microsoft.azure.functions</groupId>
+            <artifactId>azure-functions-java-library</artifactId>
+            <version>${azure.functions.java.library.version}</version>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.4.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.23.4</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>azure-functions-maven-plugin</artifactId>
+                <version>${azure.functions.maven.plugin.version}</version>
+                <configuration>
+                    <!-- function app name -->
+                    <appName>${functionAppName}</appName>
+                    <!-- function app resource group -->
+                    <resourceGroup>java-functions-group</resourceGroup>
+                    <!-- function app service plan name -->
+                    <appServicePlanName>java-functions-app-service-plan</appServicePlanName>
+                    <!-- function app region-->
+                    <!-- refers https://github.com/microsoft/azure-maven-plugins/wiki/Azure-Functions:-Configuration-Details#supported-regions for all valid values -->
+                    <region>westus</region>
+                    <!-- function pricingTier, default to be consumption if not specified -->
+                    <!-- refers https://github.com/microsoft/azure-maven-plugins/wiki/Azure-Functions:-Configuration-Details#supported-pricing-tiers for all valid values -->
+                    <!-- <pricingTier></pricingTier> -->
+                    
+                    <!-- Whether to disable application insights, default is false -->
+                    <!-- refers https://github.com/microsoft/azure-maven-plugins/wiki/Azure-Functions:-Configuration-Details for all valid configurations for application insights-->
+                    <!-- <disableAppInsights></disableAppInsights> -->
+                    <runtime>
+                        <!-- runtime os, could be windows, linux or docker-->
+                        <os>windows</os>
+                        <javaVersion>8</javaVersion>
+                        <!-- for docker function, please set the following parameters -->
+                        <!-- <image>[hub-user/]repo-name[:tag]</image> -->
+                        <!-- <serverId></serverId> -->
+                        <!-- <registryUrl></registryUrl>  -->
+                    </runtime>
+                    <appSettings>
+                        <property>
+                            <name>FUNCTIONS_EXTENSION_VERSION</name>
+                            <value>~3</value>
+                        </property>
+                    </appSettings>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>package-functions</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <overwrite>true</overwrite>
+                            <outputDirectory>${stagingDirectory}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}</directory>
+                                    <includes>
+                                        <include>host.json</include>
+                                        <include>local.settings.json</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${stagingDirectory}/lib</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <includeScope>runtime</includeScope>
+                            <excludeArtifactIds>azure-functions-java-library</excludeArtifactIds>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!--Remove obj folder generated by .NET SDK in maven clean-->
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <filesets>
+                        <fileset>
+                            <directory>obj</directory>
+                        </fileset>
+                    </filesets>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/samples/JavaAppFolder/src/main/java/groupId/Function.java
+++ b/tests/samples/JavaAppFolder/src/main/java/groupId/Function.java
@@ -1,0 +1,43 @@
+package groupId;
+
+import com.microsoft.azure.functions.ExecutionContext;
+import com.microsoft.azure.functions.HttpMethod;
+import com.microsoft.azure.functions.HttpRequestMessage;
+import com.microsoft.azure.functions.HttpResponseMessage;
+import com.microsoft.azure.functions.HttpStatus;
+import com.microsoft.azure.functions.annotation.AuthorizationLevel;
+import com.microsoft.azure.functions.annotation.FunctionName;
+import com.microsoft.azure.functions.annotation.HttpTrigger;
+
+import java.util.Optional;
+
+/**
+ * Azure Functions with HTTP Trigger.
+ */
+public class Function {
+    /**
+     * This function listens at endpoint "/api/HttpExample". Two ways to invoke it using "curl" command in bash:
+     * 1. curl -d "HTTP Body" {your host}/api/HttpExample
+     * 2. curl "{your host}/api/HttpExample?name=HTTP%20Query"
+     */
+    @FunctionName("HttpExample")
+    public HttpResponseMessage run(
+            @HttpTrigger(
+                name = "req",
+                methods = {HttpMethod.GET, HttpMethod.POST},
+                authLevel = AuthorizationLevel.ANONYMOUS)
+                HttpRequestMessage<Optional<String>> request,
+            final ExecutionContext context) {
+        context.getLogger().info("Java HTTP trigger processed a request.");
+
+        // Parse query parameter
+        final String query = request.getQueryParameters().get("name");
+        final String name = request.getBody().orElse(query);
+
+        if (name == null) {
+            return request.createResponseBuilder(HttpStatus.BAD_REQUEST).body("Please pass a name on the query string or in the request body").build();
+        } else {
+            return request.createResponseBuilder(HttpStatus.OK).body("Hello, " + name).build();
+        }
+    }
+}

--- a/tests/samples/JavaAppFolder/src/test/java/groupId/FunctionTest.java
+++ b/tests/samples/JavaAppFolder/src/test/java/groupId/FunctionTest.java
@@ -1,0 +1,53 @@
+package groupId;
+
+import com.microsoft.azure.functions.*;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.*;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+
+/**
+ * Unit test for Function class.
+ */
+public class FunctionTest {
+    /**
+     * Unit test for HttpTriggerJava method.
+     */
+    @Test
+    public void testHttpTriggerJava() throws Exception {
+        // Setup
+        @SuppressWarnings("unchecked")
+        final HttpRequestMessage<Optional<String>> req = mock(HttpRequestMessage.class);
+
+        final Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("name", "Azure");
+        doReturn(queryParams).when(req).getQueryParameters();
+
+        final Optional<String> queryBody = Optional.empty();
+        doReturn(queryBody).when(req).getBody();
+
+        doAnswer(new Answer<HttpResponseMessage.Builder>() {
+            @Override
+            public HttpResponseMessage.Builder answer(InvocationOnMock invocation) {
+                HttpStatus status = (HttpStatus) invocation.getArguments()[0];
+                return new HttpResponseMessageMock.HttpResponseMessageBuilderMock().status(status);
+            }
+        }).when(req).createResponseBuilder(any(HttpStatus.class));
+
+        final ExecutionContext context = mock(ExecutionContext.class);
+        doReturn(Logger.getGlobal()).when(context).getLogger();
+
+        // Invoke
+        final HttpResponseMessage ret = new Function().run(req, context);
+
+        // Verify
+        assertEquals(ret.getStatus(), HttpStatus.OK);
+    }
+}

--- a/tests/samples/JavaAppFolder/src/test/java/groupId/HttpResponseMessageMock.java
+++ b/tests/samples/JavaAppFolder/src/test/java/groupId/HttpResponseMessageMock.java
@@ -1,0 +1,81 @@
+package groupId;
+
+import com.microsoft.azure.functions.*;
+
+import java.util.Map;
+import java.util.HashMap;
+
+/**
+ * The mock for HttpResponseMessage, can be used in unit tests to verify if the
+ * returned response by HTTP trigger function is correct or not.
+ */
+public class HttpResponseMessageMock implements HttpResponseMessage {
+    private int httpStatusCode;
+    private HttpStatusType httpStatus;
+    private Object body;
+    private Map<String, String> headers;
+
+    public HttpResponseMessageMock(HttpStatusType status, Map<String, String> headers, Object body) {
+        this.httpStatus = status;
+        this.httpStatusCode = status.value();
+        this.headers = headers;
+        this.body = body;
+    }
+
+    @Override
+    public HttpStatusType getStatus() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public int getStatusCode() {
+        return httpStatusCode;
+    }
+
+    @Override
+    public String getHeader(String key) {
+        return this.headers.get(key);
+    }
+
+    @Override
+    public Object getBody() {
+        return this.body;
+    }
+
+    public static class HttpResponseMessageBuilderMock implements HttpResponseMessage.Builder {
+        private Object body;
+        private int httpStatusCode;
+        private Map<String, String> headers = new HashMap<>();
+        private HttpStatusType httpStatus;
+
+        public Builder status(HttpStatus status) {
+            this.httpStatusCode = status.value();
+            this.httpStatus = status;
+            return this;
+        }
+
+        @Override
+        public Builder status(HttpStatusType httpStatusType) {
+            this.httpStatusCode = httpStatusType.value();
+            this.httpStatus = httpStatusType;
+            return this;
+        }
+
+        @Override
+        public HttpResponseMessage.Builder header(String key, String value) {
+            this.headers.put(key, value);
+            return this;
+        }
+
+        @Override
+        public HttpResponseMessage.Builder body(Object body) {
+            this.body = body;
+            return this;
+        }
+
+        @Override
+        public HttpResponseMessage build() {
+            return new HttpResponseMessageMock(this.httpStatus, this.headers, this.body);
+        }
+    }
+}


### PR DESCRIPTION
### Background
To support Azure Functions Deployment Center preview, we want to enable publishing java function app from its artifact folder without the need to bind the function app name in pom.xml.

In this PR, I added an optional field call **respect-pom-xml**. This app setting is for java specific, and it will look up the local content by parsing the pom.xml file, and release the content from **${project.build.directory}/azure-functions/${functionAppName}**

After this change, we will support the following workflow:
```yml
    - name: 'Run Azure Functions Action'
      uses: Azure/functions-action@v1
      id: fa
      with:
        app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
        package: '.'
        publish-profile: '${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE }}'
        respect-pom-xml: true
```
Before the change, the customer needs to bind their package path to their Azure function app name.
```yml
    - name: 'Run Azure Functions Action'
      uses: Azure/functions-action@v1
      id: fa
      with:
        app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
        package: './target/azure-functions/${{ env.POM_FUNCTIONAPP_NAME }}'
        publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE }}
```

### Updates
1. The action will first look up the pom.xml file in publish-profile path
2. The action will parse the functionAppName field in pom.xml
3. The action will package all content in  **./azure-functions/${functionAppName}**
4. The action will upload the package via the scm/api/zipdeploy endpoint.

### Miscellaneous
1. Refactor user agent code. Fix an issue where the Kudu table show user agent as empty string.
![image](https://user-images.githubusercontent.com/48038149/101874207-4e70ef00-3b3d-11eb-8de4-e91b652ec7a3.png)
2. Add JavaAppFolder and BrokenJavaAppFolder test samples for running unit test cases.
3. Add a few more unit test cases to increase the coverage.

Example:
https://github.com/Hazhzeng/functions-action-e2e/actions/runs/414827801

cc: @anirudhgarg @aksm-ms @elliotwmsft