### PR TITLE
Fix Scm Credentials Slot Name Validation

### DIFF
--- a/src/handlers/parameterValidator.ts
+++ b/src/handlers/parameterValidator.ts
@@ -161,7 +161,7 @@ export class ParameterValidator implements IOrchestratable {
     }
 
     private validateScmCredentialsSlotName(state: StateConstant): void {
-        if (this._scmCredentials && this._scmCredentials && this._appName && this._slot) {
+        if (this._scmCredentials && this._scmCredentials.uri && this._appName && this._slot) {
             let urlName: string = this._appName;
 
             // If slot name is 'production', the url name should not contain 'production' in it

--- a/tests/handlers/parameterValidator.spec.ts
+++ b/tests/handlers/parameterValidator.spec.ts
@@ -3,6 +3,7 @@ import { resolve } from 'path';
 import { StateConstant } from '../../src/constants/state';
 import { ParameterValidator } from '../../src/handlers/parameterValidator';
 import { IScmCredentials } from '../../src/interfaces/IScmCredentials';
+import { Builder } from '../../src/managers/builder';
 
 describe('Check ParameterValidator', function () {
   let _rootPath: string;
@@ -126,6 +127,21 @@ describe('Check ParameterValidator', function () {
       password: 'password',
       uri: 'https://$sample-app-stage:password@sample-app-stage.scm.azurewebsites.net'
     };
+    const validator = new ParameterValidator();
+    // @ts-ignore
+    validator._appName = 'sample-app';
+    // @ts-ignore
+    validator._scmCredentials = scmCredential;
+    // @ts-ignore
+    validator._slot = 'STAGE';
+    assert.doesNotThrow(
+      // @ts-ignore
+      () => validator.validateScmCredentialsSlotName(StateConstant.ValidateParameter)
+    );
+  });
+
+    it('should not throw a validation error if the default scm credential is used during slot deployment', function () {
+    const scmCredential = Builder.GetDefaultScmCredential();
     const validator = new ParameterValidator();
     // @ts-ignore
     validator._appName = 'sample-app';


### PR DESCRIPTION
* Fixes #67 and #65

During commit fa15148 there was an additional check added for `this._scmCredentials`. I think this was meant to check for the existance of an uri in the scmCredentials, @Hazhzeng could you please clarify this?

I don't see any issue when doing slot deployments using zip deploy with a service principal instead of an publish profile. Please let me know if I'm missing something.