### PR TITLE
Removing BOT for need to triage

### DIFF
--- a/.github/workflows/defaultLabels.yml
+++ b/.github/workflows/defaultLabels.yml
@@ -12,17 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      - uses: actions/stale@v3
-        name: Default issue label as need-to-triage 
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-message: 'This issue is marked need-to-triage for generating issues report.'
-          stale-issue-label: 'need-to-triage'
-          days-before-stale: 0
-          days-before-close: -1
-          operations-per-run: 100
-          
+    steps:    
       - uses: actions/stale@v3
         name: Setting issue as idle
         with:


### PR DESCRIPTION
We'll be using issue template to have a default label - "need-to-triage"