### PR TITLE
Update retryCount to 3

### DIFF
--- a/src/publishers/zipDeploy.ts
+++ b/src/publishers/zipDeploy.ts
@@ -144,7 +144,7 @@ export class ZipDeploy {
 
     private static async checkAppSettingPropagatedToKudu(context: IActionContext, key: string, expectedValue: string) {
         let isSuccess: boolean = false;
-        let retryCount: number = 20;
+        let retryCount: number = 3;
         const retryInterval: number = 5000;
         while (retryCount > 0) {
             await Sleeper.timeout(retryInterval);


### PR DESCRIPTION
This is a bandage solution to alleviate the symptoms of the AppSettings not propogating to Kudu as mentioned in #86 . Because the propagation is broken both these settings retry 20 times at a 5 second interval and  200 seconds (over 3 minutes) are added to any builds using this action because of it. Setting the retry count still allows 15 seconds of redundancy but wastes far less time (just 30s) if the setting just fails to copy. 

Ultimately, I feel the settings propagation should either be fixed, or this setting removed if the propagation is unnecessary, but I don't know enough about those settings to understand how to fix it or if they are required.