### PR TITLE
Update Action to use Node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,5 +53,5 @@ branding:
   icon: 'functionapp.svg'
   color: 'blue'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'lib/main.js'


### PR DESCRIPTION
Node12 is getting deprecated in 2023 so we upgrade the action to use node 16. See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/