### PR TITLE
Add validation for Flex Consumption plan

### DIFF
--- a/src/handlers/parameterValidator.ts
+++ b/src/handlers/parameterValidator.ts
@@ -55,6 +55,7 @@ export class ParameterValidator implements IOrchestratable {
         this.validateFields(state);
         this._scmCredentials = await this.parseScmCredentials(state, this._publishProfile);
         this.validateScmCredentialsSlotName(state);
+        this.validateFlexConsumptionRequirements(state)
         return StateConstant.ValidateAzureResource;
     }
 
@@ -216,6 +217,17 @@ export class ParameterValidator implements IOrchestratable {
                     "correct casing and the publish-profile is acquired from your function app's slot rather than " +
                     "your main production site."
                 );
+            }
+        }
+    }
+
+    private validateFlexConsumptionRequirements(state: StateConstant): void{
+        if(this._sku.startsWith('flexconsumption')){
+            if (!this._remoteBuild){
+                throw new ValidationError(
+                    state,ConfigurationConstant.ParamInRemoteBuild,
+                    `Flex Consumption plan detected. Please ensure the remote-build parameter is set true due MS requirements. See more: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions?tabs=linux%2Cdotnet&pivots=method-portal#parameters`
+                )
             }
         }
     }


### PR DESCRIPTION
According to [Microsoft Azure documentation](), you need to set two values, in this case I added a validator to require `remote-build` parameter set to `true`. By default we have this parameter to `false`.

If you don't set the parameter, the pipeline will correctly execute and succefully, but none of your functions will be deployed correctly.
<img width="848" height="164" alt="image" src="https://github.com/user-attachments/assets/686dbf73-b839-49a6-aca7-3794234719dd" />
And in my function none appear:
<img width="1618" height="398" alt="image" src="https://github.com/user-attachments/assets/a623cf96-a2c5-4c7d-ba81-ecdd220f90fc" />
