### PR TITLE
Update dependency, disable ADO dependabot

### DIFF
--- a/.azuredevops/dependabot.yml
+++ b/.azuredevops/dependabot.yml
@@ -1,0 +1,4 @@
+# Mirrored repository. We use dependabot via GitHub, not Azure DevOps.
+version: 2
+enable-security-updates: false
+enable-campaigned-updates: false

--- a/tests/e2e/dotnet8/dotnet8.csproj
+++ b/tests/e2e/dotnet8/dotnet8.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.4" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.1.0" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
- Disable ADO dependabot. This is a mirrored repo, we do not want automation creating PRs in ADO.
- Address a CVE for a package in the dotnet test. Not really an issue since it is just a test project, but this is to appease the SFI dashboard